### PR TITLE
add @cycle/isolate as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "homepage": "https://github.com/Widdershin/trycycle",
   "dependencies": {
     "@cycle/dom": "^13.0.0",
+    "@cycle/isolate": "^1.4.0",
     "@cycle/xstream-run": "^3.1.0",
     "babel-core": "^6.2.1",
     "babel-preset-es2015": "^6.1.18",

--- a/src/scratchpad.js
+++ b/src/scratchpad.js
@@ -1,5 +1,6 @@
 import {run} from '@cycle/xstream-run';
 import {makeDOMDriver, h, div} from '@cycle/dom';
+import isolate from '@cycle/isolate';
 import xs from 'xstream';
 import delay from 'xstream/extra/delay';
 import debounce from 'xstream/extra/debounce';


### PR DESCRIPTION
I think it makes sense to include `isolate` to be able to try out data flow components (until npm modules can be imported).